### PR TITLE
add: Findyプロジェクトにスキルシンボリックリンクを追加

### DIFF
--- a/cc-playground/260311_Claude Codeを加速させる私の推しスキル・ツール・設定（Findyイベント登壇資料）/.agent/skills/github-upload-image-to-pr
+++ b/cc-playground/260311_Claude Codeを加速させる私の推しスキル・ツール・設定（Findyイベント登壇資料）/.agent/skills/github-upload-image-to-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/github-upload-image-to-pr

--- a/cc-playground/260311_Claude Codeを加速させる私の推しスキル・ツール・設定（Findyイベント登壇資料）/.claude/skills/github-upload-image-to-pr
+++ b/cc-playground/260311_Claude Codeを加速させる私の推しスキル・ツール・設定（Findyイベント登壇資料）/.claude/skills/github-upload-image-to-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/github-upload-image-to-pr


### PR DESCRIPTION
## Summary
- Findyイベント登壇資料学習プロジェクトに github-upload-image-to-pr スキルのシンボリックリンクを追加（`.agent/skills/`, `.claude/skills/`）

## Context
- /rewind コマンドの深掘り学習セッションでの作業成果

Closes #41